### PR TITLE
binding compatible with CNTK-2.5.1

### DIFF
--- a/dockerfiles/Dockerfile.amd64_cpu
+++ b/dockerfiles/Dockerfile.amd64_cpu
@@ -1,4 +1,4 @@
-FROM carml/base:amd64-cpu-latest
+FROM carml/base:amd64-gpu-latest
 MAINTAINER Abdul Dakkak <dakkak@illinois.edu>
 
 # Build-time metadata as defined at http://label-schema.org
@@ -25,14 +25,23 @@ WORKDIR /opt
 
 RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
 
-RUN CNTK_VERSION_DASHED=$(echo $CNTK_VERSION | tr . -) && \
-    CNTK_SHA256="fc3e4e304fc810e93b9a350a80a6872fdc64cd124fd49571bd1ff9297c212f40" && \
+RUN CNTK_VERSION_DASHED=$(echo $FRAMEWORK_VERSION | tr . -) && \
+    CNTK_SHA256="386fe7589cb8759611d68a8ed8c888bf6b5dec3c3b2772c2c6a680ffe9fcce60" && \
     wget -q https://cntk.ai/BinaryDrop/CNTK-${CNTK_VERSION_DASHED}-Linux-64bit-CPU-Only.tar.gz && \
     echo "$CNTK_SHA256 CNTK-${CNTK_VERSION_DASHED}-Linux-64bit-CPU-Only.tar.gz" | sha256sum --check --strict - && \
     tar -xzf CNTK-${CNTK_VERSION_DASHED}-Linux-64bit-CPU-Only.tar.gz && \
     rm -f CNTK-${CNTK_VERSION_DASHED}-Linux-64bit-CPU-Only.tar.gz && \
     /bin/bash /opt/cntk/Scripts/install/linux/install-cntk.sh --py-version 35 --docker
 
+########## COPYING MISSING HEADER FROM SOURCE #########
+RUN CNTK_VERSION_DASHED=$(echo $FRAMEWORK_VERSION | tr . -) && \
+    CNTK_SHA256="dacbc169e1ff9eb4b51d9e84772571dcce14aa7640d71be57e03c0a791befaf9" && \
+    wget -q https://github.com/Microsoft/CNTK/archive/v2.5.1.tar.gz && \
+    echo "$CNTK_SHA256 v${FRAMEWORK_VERSION}.tar.gz" | sha256sum --check --strict - && \
+    tar -xzf v${FRAMEWORK_VERSION}.tar.gz && \
+    rm -f v${FRAMEWORK_VERSION}.tar.gz && \
+    cp CNTK-${FRAMEWORK_VERSION}/Source/CNTKv2LibraryDll/API/HalfConverter.hpp /opt/cntk/Include/HalfConverter.hpp
+    
 ########## GO BINDING INSTALLATION ###################
 ENV PKG github.com/rai-project/go-cntk
 WORKDIR $GOPATH/src/$PKG

--- a/dockerfiles/Dockerfile.amd64_gpu
+++ b/dockerfiles/Dockerfile.amd64_gpu
@@ -26,12 +26,21 @@ WORKDIR /opt
 RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
 
 RUN CNTK_VERSION_DASHED=$(echo $FRAMEWORK_VERSION | tr . -) && \
-    CNTK_SHA256="013d1050f2f8d7240274e140f41b01a29508f2296388728aababb776fef58667" && \
+    CNTK_SHA256="8eebff81ef4111b2be5804303f1254cd20de5911a7678c8e64689e5c288dde40" && \
     wget -q https://cntk.ai/BinaryDrop/CNTK-${CNTK_VERSION_DASHED}-Linux-64bit-GPU.tar.gz && \
     echo "$CNTK_SHA256 CNTK-${CNTK_VERSION_DASHED}-Linux-64bit-GPU.tar.gz" | sha256sum --check --strict - && \
     tar -xzf CNTK-${CNTK_VERSION_DASHED}-Linux-64bit-GPU.tar.gz && \
     rm -f CNTK-${CNTK_VERSION_DASHED}-Linux-64bit-GPU.tar.gz && \
     /bin/bash /opt/cntk/Scripts/install/linux/install-cntk.sh --py-version 35 --docker
+
+########## COPYING MISSING HEADER FROM SOURCE #########
+RUN CNTK_VERSION_DASHED=$(echo $FRAMEWORK_VERSION | tr . -) && \
+    CNTK_SHA256="dacbc169e1ff9eb4b51d9e84772571dcce14aa7640d71be57e03c0a791befaf9" && \
+    wget -q https://github.com/Microsoft/CNTK/archive/v2.5.1.tar.gz && \
+    echo "$CNTK_SHA256 v${FRAMEWORK_VERSION}.tar.gz" | sha256sum --check --strict - && \
+    tar -xzf v${FRAMEWORK_VERSION}.tar.gz && \
+    rm -f v${FRAMEWORK_VERSION}.tar.gz && \
+    cp CNTK-${FRAMEWORK_VERSION}/Source/CNTKv2LibraryDll/API/HalfConverter.hpp /opt/cntk/Include/HalfConverter.hpp
 
 ########## GO BINDING INSTALLATION ###############
 ENV PKG github.com/rai-project/go-cntk

--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -52,7 +52,7 @@ BUILD_ARGS = --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		         --build-arg VCS_URL=`git config --get remote.origin.url` \
 		         --build-arg VCS_REF=$(GIT_COMMIT) \
 		         --build-arg ARCH=$(ARCH) \
-						 --build-arg FRAMEWORK_VERSION="2.3"
+						 --build-arg FRAMEWORK_VERSION="2.5.1"
 
 docker_build_gpu: # Build GPU Docker image
 	@docker build $(BUILD_ARGS) \

--- a/lib.go
+++ b/lib.go
@@ -2,14 +2,14 @@
 
 package cntk
 
-// #cgo LDFLAGS: -lCntk.Core-2.3
-// #cgo LDFLAGS: -lCntk.Math-2.3
-// #cgo LDFLAGS: -lCntk.PerformanceProfiler-2.3
-// #cgo LDFLAGS: -lCntk.Eval-2.3
+// #cgo LDFLAGS: -lCntk.Core-2.5.1
+// #cgo LDFLAGS: -lCntk.Math-2.5.1
+// #cgo LDFLAGS: -lCntk.PerformanceProfiler-2.5.1
+// #cgo LDFLAGS: -lCntk.Eval-2.5.1
 // #cgo LDFLAGS: -lmklml_intel -liomp5 -L${SRCDIR} -lstdc++
-// #cgo LDFLAGS: -L/opt/cntk/cntk/lib -L/opt/cntk/cntk/dependencies/lib -L/opt/frameworks/cntk/cntk/lib -L/opt/frameworks/cntk/cntk/dependencies/lib
+// #cgo LDFLAGS: -L/home/as29/my_cntk/cntk/cntk/lib -L/home/as29/my_cntk/cntk/cntk/dependencies/lib
 // #cgo CXXFLAGS: -std=c++11 -O3 -Wall -g
 // #cgo CXXFLAGS: -Wno-sign-compare -Wno-unused-function -Wno-reorder -Wno-unknown-pragmas
-// #cgo CXXFLAGS: -I/usr/local/cuda/include -I/opt/cntk/Include -I/opt/frameworks/cntk/Include
+// #cgo CXXFLAGS: -I/usr/local/cuda/include -I/home/as29/my_cntk/cntk/Include 
 // #cgo CXXFLAGS: -I${SRCDIR}/cbits -I${SRCDIR}/cbits/util -I${SRCDIR}/cuda
 import "C"


### PR DESCRIPTION
modified lib.go to make it compatible with v2.5.1, also in the process of modifying dockerfiles for x86 machines